### PR TITLE
Use \DeclarePairedDelimiter instead of \def to define ceil and floor.

### DIFF
--- a/math_commands.tex
+++ b/math_commands.tex
@@ -53,8 +53,8 @@
 \def\Partref#1{Part~\ref{#1}}
 \def\twopartref#1#2{parts \ref{#1} and \ref{#2}}
 
-\def\ceil#1{\lceil #1 \rceil}
-\def\floor#1{\lfloor #1 \rfloor}
+\DeclarePairedDelimiter{\ceil}{\lceil}{\rceil}
+\DeclarePairedDelimiter{\floor}{\lfloor}{\rfloor}
 \def\1{\bm{1}}
 \newcommand{\train}{\mathcal{D}}
 \newcommand{\valid}{\mathcal{D_{\mathrm{valid}}}}

--- a/notation_example.tex
+++ b/notation_example.tex
@@ -42,6 +42,7 @@
 \usepackage{multirow}
 \usepackage{colortbl}
 \usepackage{booktabs}
+\usepackage{mathtools}
 % This allows us to cite chapters by name, which was useful for making the
 % acknowledgements page
 \usepackage{nameref}


### PR DESCRIPTION
Using \DeclarePairedDelimiter offers much more benefit such as auto scaling of the paired operator.
See

https://tex.stackexchange.com/questions/94410/easily-change-behavior-of-declarepaireddelimiter

for some examples.